### PR TITLE
feat(Tangopbx): update RSSFEEDS to include ClearlyIP feed

### DIFF
--- a/Tangopbx.class.php
+++ b/Tangopbx.class.php
@@ -35,7 +35,7 @@ class Tangopbx extends FreePBX_Helpers implements BMO
 		'VIEW_FOOTER_CONTENT' => 'modules/__RAWNAME__/views/footer_content.php',
 		'VIEW_LOGIN' => 'modules/__RAWNAME__/views/login.php',
 		'SIPUSERAGENT' => '__BRAND__',
-		'RSSFEEDS' => '',
+		'RSSFEEDS' => 'https://clearlyip.com/feed/',
 		'USE_FREEPBX_MENU_CONF' => true
 	);
 


### PR DESCRIPTION
- Changed 'RSSFEEDS' from an empty string to 'https://clearlyip.com/feed/'.
- This update provides users with relevant RSS feed information for better integration.

Ref: CMM-68