### PR TITLE
chore(module.xml): remove alias from command definition

### DIFF
--- a/module.xml
+++ b/module.xml
@@ -21,7 +21,6 @@
 	<console>
 		<command>
 			<name>tangopbx</name>
-			<alias>tp</alias>
 			<class>Tangopbx</class>
 		</command>
 	</console>


### PR DESCRIPTION
- Removed the alias "tp" from the command in module.xml
- Simplifies the command structure for TangoPBX

Closes #2 Installing tangopbx module affects output from fwconsole list